### PR TITLE
Don't test Ruby 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
+language: ruby
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+    - rvm: jruby-head
+
 rvm:
   - 1.9.2
   - 1.9.3


### PR DESCRIPTION
Travis builds are failing due to attempts to test Ruby 1.8 mode which is not supported by Celluloid.
