### PR TITLE
migrate the plugin to use 'guard-compat'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ matrix:
     - rvm: jruby-head
 
 rvm:
-  - 1.9.2
   - 1.9.3
   - jruby-19mode # JRuby in 1.9 mode
   - rbx-19mode

--- a/guard-sidekiq.gemspec
+++ b/guard-sidekiq.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.description = %q{Guard::Sidekiq automatically starts/stops/restarts sidekiq worker}
 
   s.add_dependency 'guard', '>= 2'
+  s.add_dependency('guard-compat', '~> 1.0')
   s.add_dependency 'sidekiq'
 
   s.add_development_dependency 'bundler'

--- a/lib/guard/sidekiq.rb
+++ b/lib/guard/sidekiq.rb
@@ -1,4 +1,4 @@
-require 'guard'
+require 'guard/compat/plugin'
 require 'timeout'
 
 module Guard
@@ -28,8 +28,8 @@ module Guard
 
     def start
       stop
-      UI.info 'Starting up sidekiq...'
-      UI.info cmd
+      Guard::Compat::UI.info 'Starting up sidekiq...'
+      Guard::Compat::UI.info cmd
 
       # launch Sidekiq worker
       @pid = spawn({}, cmd)
@@ -37,28 +37,28 @@ module Guard
 
     def stop
       if @pid
-        UI.info 'Stopping sidekiq...'
+        Guard::Compat::UI.info 'Stopping sidekiq...'
         ::Process.kill @stop_signal, @pid
         begin
           Timeout.timeout(15) do
             ::Process.wait @pid
           end
         rescue Timeout::Error
-          UI.info 'Sending SIGKILL to sidekiq, as it\'s taking too long to shutdown.'
+          Guard::Compat::UI.info 'Sending SIGKILL to sidekiq, as it\'s taking too long to shutdown.'
           ::Process.kill :KILL, @pid
           ::Process.wait @pid
         end
-        UI.info 'Stopped process sidekiq'
+        Guard::Compat::UI.info 'Stopped process sidekiq'
       end
     rescue Errno::ESRCH
-      UI.info 'Guard::Sidekiq lost the Sidekiq worker subprocess!'
+      Guard::Compat::UI.info 'Guard::Sidekiq lost the Sidekiq worker subprocess!'
     ensure
       @pid = nil
     end
 
     # Called on Ctrl-Z signal
     def reload
-      UI.info 'Restarting sidekiq...'
+      Guard::Compat::UI.info 'Restarting sidekiq...'
       restart
     end
 

--- a/spec/guard/sidekiq_spec.rb
+++ b/spec/guard/sidekiq_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
+require 'guard/compat/test/helper'
 
-describe Guard::Sidekiq do
+describe Guard::Sidekiq, exclude_stubs: [Guard::Plugin] do
   describe 'start' do
 
     it 'accepts :environment option' do


### PR DESCRIPTION
Migrate the plugin to use `guard-compat` in order to avoid `NoMethodError: undefined method `session' for nil:NilClass` when testing the plugin (see guard/guard#693).